### PR TITLE
move roadmap tab higher on table of contents list

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -3,6 +3,7 @@
 ## 👋 Welcome
 
 * [Introduction](README.md)
+* [Roadmap](resources/roadmap.md)
 
 ## 🗳 Governance
 
@@ -59,7 +60,6 @@
 ## 🗃 Resources
 
 * [Our Team](resources/our-team.md)
-* [Roadmap](resources/roadmap.md)
 * [Harvest Stats](resources/harvest-stats.md)
 * [Brand Assets](resources/brand-assets.md)
 * [Guides](resources/guides/README.md)


### PR DESCRIPTION
On my screen, to see the `Roadmap` section, i have to scroll down. A slight suggestion to raise visibility of `Roadmap` section. As snowball transitions into a venture dao, the planned ventures should be easier to locate in the documentation. The current placement in `Resources` gives me a "in case you want more info" tone. This slight modification mildly eases communication in the `Introduction` section to answer "what is snowball" and "where snowball is going". If not here, i could see it in the `Products` section as well.

Also, the term "venture dao" is not mentioned anywhere in the documentation. If you see fit, I can add a some short sentences mentioning the transition.



